### PR TITLE
Adds optional parameter to CreateSubMenuItem

### DIFF
--- a/RadialUIPlugin/RadialSubmenu.cs
+++ b/RadialUIPlugin/RadialSubmenu.cs
@@ -96,7 +96,7 @@ namespace RadialUI
         /// <param name="title">Text associated with the sub-menu item</param>
         /// <param name="icon">Icon associated with the sub-menu item</param>
         /// <param name="callback">Callback that is called when the sub-menu item is selected</param>
-        public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon, Action<CreatureGuid, string, MapMenuItem> callback)
+        public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon, Action<CreatureGuid, string, MapMenuItem> callback, bool closeMenu = true)
         {
             // Check if the main menu Guid exists
             if (!subMenuEntries.ContainsKey(mainGuid))
@@ -111,7 +111,7 @@ namespace RadialUI
                 Action = (mmi, obj) => { callback(radialAsset, mainGuid, mmi); },
                 Icon = icon,
                 Title = title,
-                CloseMenuOnActivate = true
+                CloseMenuOnActivate = closeMenu
             });
         }
 
@@ -122,7 +122,7 @@ namespace RadialUI
         /// <param name="title">Text associated with the sub-menu item</param>
         /// <param name="icon">Icon associated with the sub-menu item</param>
         /// <param name="callback">Callback that is called when the sub-menu item is selected</param>
-        public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon, Action<HideVolumeItem, string, MapMenuItem> callback)
+        public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon, Action<HideVolumeItem, string, MapMenuItem> callback, bool closeMenu = true)
         {
             // Check if the main menu Guid exists
             if (!subMenuEntries.ContainsKey(mainGuid))
@@ -137,7 +137,7 @@ namespace RadialUI
                 Action = (mmi, obj) => { callback(radialHideVolume, mainGuid, mmi); },
                 Icon = icon,
                 Title = title,
-                CloseMenuOnActivate = true
+                CloseMenuOnActivate = closeMenu
             });
         }
 


### PR DESCRIPTION
Added optional closeMenu parameter to the CreateSubMenuItem methods.

This allows the user to dictated when adding sub menu items if the selection causes the menu to close or not. Previous code hard coded a true value which meant it was not possible to do a sub-menu from a sub-menu.

The proposed change adds a closeMenu as an optional parameter. If not specified, it defaults to the previous hard coded true thus making it backwards compatible with code already using the Radial UI plugin. However, by specifying the parameter it is possible to indicated that the sub-menu should not be closed and thus allow the creation of any levels of sub-menus.